### PR TITLE
[Feature] No chardet dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,7 @@ Do not allow prints in your python code anymore. Official repository of NoPrint 
 
 ## Requirements
 
-You shouldn't have problems using this package.
-```bash
-noprint
-  - chardet [required: >=2.1.1]  # Working decode (UniversalDetector)
-```
+There's ***NONE***! You can use this package to your heart's content. Unless you'd like to develop for it, for this you'll need Black, Pylint and Pytest along with Pytest-cov.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = [
-  'chardet >= 2.2.1'
-]
+dependencies = []
 
 [project.urls]
 "Homepage" = "https://github.com/rgryta/NoPrint"

--- a/src/noprint/__init__.py
+++ b/src/noprint/__init__.py
@@ -1,3 +1,5 @@
 """
 Initial module for NoPrint containing constants and cli reference
 """
+
+ENCODING_CAPTURE = "^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)"

--- a/tests/test_sprint.py
+++ b/tests/test_sprint.py
@@ -58,9 +58,9 @@ def test__get_prints(mock_subpackages, mock_open, first, code):
             return
 
     mock_subpackages.side_effect = _subpackages
-    mock_open.return_value.read.return_value = "Testing".encode("utf-8")
 
     fin = mock.Mock()
+    fin.return_value.readline.return_value = "# -*- coding: utf-8-sig -*-"
     fin.return_value.read.return_value = code
     mock_open.return_value.__enter__ = fin
 
@@ -69,3 +69,4 @@ def test__get_prints(mock_subpackages, mock_open, first, code):
         assert "Line:" in prints[0]
     else:
         assert len(prints) == 0
+    mock_open.assert_called_with("origin", "r", encoding="utf-8-sig")


### PR DESCRIPTION
Removed chardet dependency as Python requires UTF8 or properly specified encoding in 1st two lines of source code.