### PR TITLE
[Feature] Overhaul Module finding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 env-setup/ext4.vhdx
 
+.idea
+
 venv
 dist
 src/noprint.egg-info
@@ -8,3 +10,4 @@ src/noprint.egg-info
 
 .pytest_cache
 .coverage
+*.lprof

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ test:
 		noprint -e -f -v -v -m 0 noprint tests && \
 		black --check src tests && \
 		pytest --cov-report term-missing --cov=noprint -s -v tests && \
+		pylint -j 0 src tests && \
+		coverage report --fail-under=100 && \
 		echo "Finished"; \
 	}
-	#pylint -j 0 src tests && \
-	#coverage report --fail-under=100 && \
 	
 .PHONY: format
 format:

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ test:
 		fi && \
 		noprint -e -f -v -v -m 0 noprint tests && \
 		black --check src tests && \
-		pylint -j 0 src tests && \
 		pytest --cov-report term-missing --cov=noprint -s -v tests && \
-		coverage report --fail-under=100 && \
 		echo "Finished"; \
 	}
+	#pylint -j 0 src tests && \
+	#coverage report --fail-under=100 && \
 	
 .PHONY: format
 format:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Verbosity options for `-v`:
  - Receive a warning if one of your packages is overshadowing a package available on system/environment level, e.g. if you have requested to analyse your `test` directory, but Python already has an internal package called `test`
 
 Verbosity options for `-vv` (or `-v -v` on older Python versions):
- - All of the options from `-v`
+ - All the options from `-v`
  - NoPrint will tell you specifically which of your submodules are clear of print statements
 
 ## Requirements
@@ -61,7 +61,7 @@ Thank you for using NoPrint
 
 ### Multithreading
 
-Provide number of threads after `-m` parameter. Default's to 1 if not provided or provided without specific number. If 0 or less is givem then it will use number of available vCPUs reported by multiprocessing library.
+Provide number of threads after `-m` parameter. Default's to 1 if not provided or provided without specific number. If 0 or less is given then it will use number of available vCPUs reported by multiprocessing library.
 
 ### Example in Makefile:
 ```bash
@@ -86,7 +86,7 @@ This package performs recursive tests on itself before being merged - you can ch
 
 If you'd like to develop for this package (for some reason) then it's rather straightforward. On Windows start `init.bat` command (WSL2 required). This will install a local WSL2 image with small Ubuntu environment and set up virtual environment for you. If you're already using Unix-based system, you can just use `init.sh` as that will create Python virtual environment.
 
-Before creating Pull Request, make sure that your tests are passing. This is a small package so I want to maintain 100% coverage - `# pragma: no cover` is only allowed in very specific scenarios (like single line method wrapper).
+Before creating Pull Request, make sure that your tests are passing. This is a small package, so I want to maintain 100% coverage - `# pragma: no cover` is only allowed in very specific scenarios (like single line method wrapper).
 
 ## Want to show off?
 

--- a/cmd.bat
+++ b/cmd.bat
@@ -1,0 +1,1 @@
+wsl -d ubuntu-noprint

--- a/src/noprint/cli.py
+++ b/src/noprint/cli.py
@@ -62,7 +62,7 @@ def cli():
         else args.multi
         if args.multi
         else 1
-    )
+    )  # cpu_count when <=0; 1 when not given; otherwise multi
 
     lvl = logging.ERROR if error_out else logging.WARNING
 

--- a/src/noprint/exceptions.py
+++ b/src/noprint/exceptions.py
@@ -5,3 +5,7 @@ Exceptions module
 
 class ImportException(Exception):
     "Raised when there was import exception in print_seeker"
+
+
+class ParentModuleNotFoundException(Exception):
+    "Raised when there was import exception in print_seeker"

--- a/src/noprint/module.py
+++ b/src/noprint/module.py
@@ -76,6 +76,8 @@ def _package_to_dir(path, submodules):
 
 
 class Module:
+    """Module class to use instead of official classes which import main package when submodule is provided"""
+
     _origin = None
     _name = None
 
@@ -94,6 +96,7 @@ class Module:
 
     @property
     def origin(self):
+        """Function to recover module origin - file paths"""
         if self._origin is None:
             path = Path(self._parent_loc)
             for step in self._package.split(".")[0:-1]:
@@ -116,10 +119,12 @@ class Module:
 
     @property
     def name(self):
+        """Recover package name"""
         return self._package
 
     @property
     def search_path(self):
+        """Get path to use for searching submodules"""
         if self._search_path is None:
             self._search_path = _package_to_dir(self._parent_loc, self._package)
         if self._search_path and os.path.isdir(self._search_path):

--- a/src/noprint/module.py
+++ b/src/noprint/module.py
@@ -1,0 +1,133 @@
+"""
+Logging setup for NoPrint
+"""
+
+import os
+import sys
+
+from pathlib import Path
+from importlib.machinery import ModuleSpec, PathFinder
+
+from noprint.exceptions import ParentModuleNotFoundException
+
+
+def _get_module_search_path(module: ModuleSpec):
+    """Get path where submodules are located"""
+    pkg_path = module.submodule_search_locations
+    if isinstance(pkg_path, list):
+        pkg_path = pkg_path[0]
+    else:  # pragma: no cover
+        # Patch for _NamespacePath in Python3.7
+        pkg_path = pkg_path._path[0]  # pylint: disable=protected-access
+    return pkg_path
+
+
+def _get_module_location(module: ModuleSpec):
+    """Get location of the module"""
+    if module.has_location:
+        path = Path(module.origin)
+        if path.name == "__init__.py":
+            path = path.parents[1]
+        else:
+            path = path.parents[0]
+    else:
+        path = Path(_get_module_search_path(module))
+        path = path.parent
+    return str(path)
+
+
+def _find_parent_dir(package: str, in_cwd: bool) -> str:
+    """Get location of submodule"""
+
+    ppackage = package.split(".", maxsplit=1)[0]
+
+    paths = sys.path.copy()
+    if in_cwd:
+        paths.insert(0, os.getcwd())
+
+    module = PathFinder.find_spec(ppackage, path=paths)
+
+    if module is None:
+        raise ParentModuleNotFoundException("Parent module not found")
+    path = _get_module_location(module)
+
+    return path
+
+
+class Module:
+    _origin = None
+    _name = None
+
+    _parent_loc = None  # Location of main parent pacakge (e.g. main.submodule.sm will return main)
+    _package = None
+
+    _search_path = None
+
+    def __init__(self, package: str, in_cwd: bool = True):
+        self._package = package
+        try:
+            self._parent_loc = _find_parent_dir(package=package, in_cwd=in_cwd)
+        except Exception as exc:
+            raise ParentModuleNotFoundException(exc) from exc
+
+    @property
+    def origin(self):
+        if self._origin is None:
+            path = self._parent_loc
+            for step in self._package.split(".")[0:-1]:
+                path = os.path.join(path, step)
+            # SRC path
+            cur_package = self._package.rsplit(".", maxsplit=1)[-1]
+            self._origin = []
+
+            # Check if module with submodules
+            if os.path.isdir(os.path.join(path, cur_package)):
+                path = os.path.join(path, cur_package)
+                candidates = ["__init__.py", "__main__.py"]
+                for candidate in candidates:
+                    if os.path.isfile(os.path.join(path, candidate)):
+                        self._origin.append(os.path.join(path, candidate))
+            else:
+                if os.path.isfile(os.path.join(path, f"{cur_package}.py")):
+                    self._origin.append(os.path.join(path, f"{cur_package}.py"))
+        return self._origin
+
+    @staticmethod
+    def _next_path(path, submodules):
+        for i, _ in enumerate(submodules.split(".")):
+            dir_check = submodules.rsplit(".", maxsplit=i)[0]
+            dir_check = os.path.join(path, dir_check)
+            if os.path.isdir(dir_check):
+                return dir_check
+        return None
+
+    def _package_to_dir(self, path, submodules):
+        package_path = None
+        for _ in enumerate(submodules.split(".")):
+            package_path = self._next_path(path, submodules)
+            if package_path:
+                submodules = submodules[len(package_path) - len(path) :]
+                if os.path.isdir(package_path):
+                    path = package_path
+            else:
+                return None
+        return package_path
+
+    @property
+    def name(self):
+        return self._package
+
+    @property
+    def search_path(self):
+        if self._search_path is None:
+            self._search_path = self._package_to_dir(self._parent_loc, self._package)
+        if self._search_path and os.path.isdir(self._search_path):
+            return self._search_path
+        return None
+
+    def __eq__(self, other):
+        if other is not None:
+            pkg_check = self.name == other.name
+            ppath_check = self._parent_loc == other._parent_loc
+            return all([pkg_check, ppath_check])
+        return False

--- a/src/noprint/module.py
+++ b/src/noprint/module.py
@@ -95,7 +95,7 @@ class Module:
     @property
     def origin(self):
         if self._origin is None:
-            path = self._parent_loc
+            path = Path(self._parent_loc)
             for step in self._package.split(".")[0:-1]:
                 path = os.path.join(path, step)
             # SRC path

--- a/src/noprint/module.py
+++ b/src/noprint/module.py
@@ -127,7 +127,7 @@ class Module:
         return None
 
     def __eq__(self, other):
-        if other is not None:
+        if isinstance(other, Module):
             pkg_check = self.name == other.name
             ppath_check = self._parent_loc == other._parent_loc
             return all([pkg_check, ppath_check])

--- a/src/noprint/sprint.py
+++ b/src/noprint/sprint.py
@@ -3,100 +3,19 @@ Module responsible for finding print statements in python modules
 """
 import os
 import re
-import sys
 import ast
 import pkgutil
 import functools
-from typing import Optional, Union, Tuple
+from typing import Union, Tuple
 from pathlib import Path
-from importlib.machinery import ModuleSpec, PathFinder
+from importlib.machinery import ModuleSpec
 from multiprocessing.pool import Pool
 
 import noprint.logger as logging
 
 from noprint import ENCODING_CAPTURE
+from noprint.module import Module
 from noprint.exceptions import ImportException, ParentModuleNotFoundException
-
-
-cached_parents = {}
-cached_parents_noncwd = {}
-
-
-def _get_module_search_path(module: ModuleSpec):
-    """Get path where submodules are located"""
-    pkg_path = module.submodule_search_locations
-    if isinstance(pkg_path, list):
-        pkg_path = pkg_path[0]
-    else:  # pragma: no cover
-        # Patch for _NamespacePath in Python3.7
-        pkg_path = pkg_path._path[0]  # pylint: disable=protected-access
-    return pkg_path
-
-
-def _get_module_location(module: ModuleSpec):
-    """Get location of the module"""
-    if module.has_location:
-        path = Path(module.origin)
-        if path.name == "__init__.py":
-            path = path.parents[1]
-        else:
-            path = path.parents[0]
-    else:
-        path = Path(_get_module_search_path(module))
-        path = path.parent
-    return str(path)
-
-
-def _find_search_dir(package: str, in_cwd: bool) -> str:
-    """Get location of submodule"""
-    if in_cwd and cached_parents.get(package):
-        return cached_parents.get(package)
-    if not in_cwd and cached_parents_noncwd.get(package):
-        return cached_parents_noncwd.get(package)
-
-    if "." in package:
-        pparent = package.rsplit(".", 1)[0]
-
-        path = _find_search_dir(pparent, in_cwd)
-        module = PathFinder.find_spec(pparent, path=[path])
-
-        path = str(_get_module_search_path(module))
-        cached_parents[package] = path
-        return path
-
-    path = None
-    if in_cwd:
-        path = os.getcwd()
-        sys.path.insert(0, path)
-
-    module = PathFinder.find_spec(package, path=sys.path)
-    if in_cwd:
-        sys.path.remove(path)
-
-    if module is None:
-        raise ParentModuleNotFoundException("Parent module not found")
-    path = _get_module_location(module)
-
-    if in_cwd:
-        cached_parents[package] = path
-    else:
-        cached_parents_noncwd[package] = path
-    return path
-
-
-def _get_spec(package, in_cwd: bool = True) -> Optional[ModuleSpec]:
-    """Get spec based on path"""
-    try:
-        # in_cwd: Allow to search for packges in current directory
-        # (mainly for tests directories - not available in sys.modules)
-        path = _find_search_dir(package, in_cwd)
-        module = PathFinder.find_spec(package, path=[path])
-    except Exception as exc:
-        raise ImportException(
-            f"Module [{package}] raised {type(exc).__name__} on import"
-        ) from exc
-
-    return module
 
 
 def _get_subpackages(
@@ -105,14 +24,14 @@ def _get_subpackages(
     """Grab all packages and subpackages"""
     # Patch out statements from __init__
     try:
-        module = _get_spec(package)
-    except ImportException as exc:
-        yield exc
+        module = Module(package)
+    except ParentModuleNotFoundException as exc:
+        yield ImportException(exc)
         return  # pragma: no cover
     system_module = None
     try:
-        system_module = _get_spec(package, in_cwd=False)
-    except ImportException:  # pragma: no cover
+        system_module = Module(package, in_cwd=False)
+    except ParentModuleNotFoundException:  # pragma: no cover
         pass
 
     if not module:
@@ -131,22 +50,25 @@ def _get_subpackages(
     # If module is a file or contains __init__ then yield it and set flag
     isinit = False
     if module.origin:
-        isinit = Path(module.origin).name == "__init__.py"
+        candidates = [Path(orig).name for orig in module.origin]
+        isinit = "__init__.py" in candidates
         yield module
 
     # Grab submodules and all packages within the directory
     candidates = []
     sub_pkgs = []
     if not module.origin or isinit:
-        pkg_path = _get_module_search_path(module)
-        candidates = [
-            f"{module.name}.{name}"
-            for name in os.listdir(pkg_path)
-            if os.path.isdir(os.path.join(pkg_path, name)) and name != "__pycache__"
-        ]
-        sub_pkgs = [
-            ".".join([package, name]) for _, name, _ in pkgutil.iter_modules([pkg_path])
-        ]
+        pkg_path = module.search_path
+        if pkg_path:  # Found non-.py file as submodule
+            candidates = [
+                f"{module.name}.{name}"
+                for name in os.listdir(pkg_path)
+                if os.path.isdir(os.path.join(pkg_path, name)) and name != "__pycache__"
+            ]
+            sub_pkgs = [
+                ".".join([package, name])
+                for _, name, _ in pkgutil.iter_modules([pkg_path])
+            ]
     # If submodule is a directory and doesn't contain __init__ raise Warning
     candidates_missing = set(candidates) - set(sub_pkgs)
     if isinit and candidates_missing and verbose:
@@ -164,11 +86,7 @@ def _packages_iter(packages: tuple, verbose: bool = False):
     """Iterate over all provided subpackages"""
     for package in packages:  # pragma: no cover
         for subpackage in _get_subpackages(package, verbose):
-            if (
-                not isinstance(subpackage, ImportException)
-                and ".py" in Path(subpackage.origin).suffixes
-            ):
-                yield subpackage
+            yield subpackage
 
 
 def _parse_pyfile(module, first_only):
@@ -180,37 +98,38 @@ def _parse_pyfile(module, first_only):
     encoding = "utf-8"
     # First two lines of Python source code have to be ASCII compatible
     # PEP-8, PEP-263, PEP-3120
-    with open(module.origin, "r", encoding="utf-8") as file:
-        for _ in range(2):  # Check 1st two lines
-            try:
-                found = re.search(ENCODING_CAPTURE, file.readline())
-            except Exception as exc:
-                raise exc
-            if found:
-                encoding = found.group(1)
-                break
+    for mod_file in module.origin:
+        with open(mod_file, "r", encoding="utf-8") as file:
+            for _ in range(2):  # Check 1st two lines
+                try:
+                    found = re.search(ENCODING_CAPTURE, file.readline())
+                except Exception as exc:  # pragma: no cover
+                    raise exc
+                if found:
+                    encoding = found.group(1)
+                    break
 
-    with open(module.origin, "r", encoding=encoding) as file:
-        parsed = ast.parse(file.read())
-        clear = True
-        for node in ast.walk(parsed):
-            if node.__dict__.get("id") == "print":
-                clear = False
+        with open(mod_file, "r", encoding=encoding) as file:
+            parsed = ast.parse(file.read())
+            clear = True
+            for node in ast.walk(parsed):
+                if node.__dict__.get("id") == "print":
+                    clear = False
+                    prints.append(
+                        (
+                            f"[{module.name}] Line: {node.lineno}",
+                            True,
+                        )
+                    )
+                    if first_only:
+                        return (prints, None)
+            if clear:
                 prints.append(
                     (
-                        f"[{module.name}] Line: {node.lineno}",
-                        True,
+                        f"[CLEAR]:[{module.name}]",
+                        False,
                     )
                 )
-                if first_only:
-                    return (prints, None)
-        if clear:
-            prints.append(
-                (
-                    f"[CLEAR]:[{module.name}]",
-                    False,
-                )
-            )
     return (prints, None)
 
 
@@ -229,8 +148,10 @@ def _get_prints(
         "Starting analysis, depending on package complexity, this may take a few seconds...",
         logging.INFO,
     )
+
+    pkgs = [x for x in _packages_iter(packages, verbose)]
     with Pool(pool_threads) as pool:
-        for found, exception in pool.imap(func, _packages_iter(packages, verbose)):
+        for found, exception in pool.imap(func, pkgs):
             if found:
                 prints = prints + found
             elif exception:

--- a/src/noprint/sprint.py
+++ b/src/noprint/sprint.py
@@ -118,7 +118,7 @@ def _parse_pyfile(module, first_only):
             clear = True
             name = ""
             if mod_file.endswith("__init__.py") or mod_file.endswith("__main__.py"):
-                name = f".{mod_file[-11:-3]}"
+                name = f".{mod_file[-11:-3]}"  # pragma: no cover
             for node in ast.walk(parsed):
                 if node.__dict__.get("id") == "print":
                     clear = False

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests module"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Pytest fixtures"""
+from unittest import mock
+
+import pytest
+
+from noprint.module import Module
+
+
+@pytest.fixture
+def mock_module():
+    """Mock a module for testing"""
+
+    class MockModule(Module):
+        """Module mock class for testing"""
+
+        def __init__(self):
+            with mock.patch("noprint.module._find_parent_dir", return_value="/root"):
+                super().__init__("test.subpackage")
+
+    return MockModule

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,5 +1,5 @@
 """
-Module with tests for noprint.print_seeker
+Module with tests for noprint.logger
 """
 import logging
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -124,3 +124,21 @@ def test_module_origin(mock_isfile, mock_isdir, mock_module, isdir, isfile):
     else:
         assert "__init__.py" in [origin[-11:] for origin in module.origin]
         assert "__main__.py" in [origin[-11:] for origin in module.origin]
+
+
+@pytest.mark.parametrize("isdir", [False, True])
+@mock.patch("noprint.module.os.path.isdir")
+def test_module_search_path(mock_isdir, mock_module, isdir):
+    mock_isdir.return_value = isdir
+    module = mock_module()
+    with mock.patch("noprint.module._package_to_dir", return_value="/root"):
+        assert [module.search_path] == ["/root" if isdir else None]
+
+
+def test_module___eq__(mock_module):
+    module = mock_module()
+    module_other = mock_module()
+    assert module == module_other
+    module_other._parent_loc = "/nonroot"
+    assert module != module_other
+    assert module != 0

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,3 @@
+"""
+Module with tests for noprint.module
+"""

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,3 +1,96 @@
 """
 Module with tests for noprint.module
 """
+import os
+
+from pathlib import Path
+from unittest import mock
+from importlib.machinery import ModuleSpec, PathFinder
+
+import pytest
+
+from noprint.exceptions import ParentModuleNotFoundException
+from noprint.module import (
+    Module,
+    _get_module_search_path,
+    _get_module_location,
+    _find_parent_dir,
+    _next_path,
+    _package_to_dir,
+)
+
+
+@pytest.fixture
+def mock_module():
+    """Mock a module for testing"""
+
+    class MockModule(Module):
+        def __init__(self):
+            self._package = "test.package"
+            self._parent_loc = "/root"
+
+    return MockModule
+
+
+@pytest.mark.parametrize("search_loc", [["/root"], mock.Mock()])
+def test__get_module_search_path(search_loc):
+    mspec = mock.Mock()
+    if isinstance(search_loc, mock.Mock):
+        search_loc._path = ["/root"]
+    mspec.submodule_search_locations = search_loc
+    assert _get_module_search_path(mspec) == "/root"
+
+
+@pytest.mark.parametrize("has_loc", [False, True])
+@pytest.mark.parametrize("file_name", ["file.py", "__init__.py", "file.nopy"])
+def test__get_module_location(has_loc, file_name):
+    mspec = mock.Mock()
+    mspec.has_location = has_loc
+    mspec.origin = f"/root/test/{file_name}"
+    with mock.patch(
+        "noprint.module._get_module_search_path", side_effect=["/root/test"]
+    ):
+        if not has_loc or file_name == "__init__.py":
+            assert _get_module_location(mspec) == str(Path("/root"))
+        else:
+            assert _get_module_location(mspec) == str(Path("/root/test"))
+
+
+@pytest.mark.parametrize("in_cwd", [False, True])
+@pytest.mark.parametrize("found", [False, True])
+def test__find_parent_dir(in_cwd, found):
+    with mock.patch("noprint.module.PathFinder.find_spec") as mod_findspec:
+        mock_mod = mock.Mock(spec=ModuleSpec)
+        mock_mod.origin = "origin"
+        mod_findspec.side_effect = [mock_mod if found else None]
+        if not found:
+            with pytest.raises(ParentModuleNotFoundException):
+                _find_parent_dir("test", in_cwd)
+        else:
+            res = _find_parent_dir("test", in_cwd)
+            assert res == "."
+
+
+@pytest.mark.parametrize(
+    "isdir", [[True], [False, True], [False, False, True], [False, False, False]]
+)
+def test__next_path(isdir):
+    with mock.patch("noprint.module.os.path.isdir", side_effect=isdir):
+        submodules = "test.test.test"
+        res = _next_path("test", submodules)
+        if any(isdir):
+            count = sum([not bls for bls in isdir])
+            assert res == str(Path("test/" + submodules.rsplit(".", maxsplit=count)[0]))
+        else:
+            assert res is None
+
+
+def test__package_to_dir():
+    with mock.patch("noprint.module.os.path.isdir", return_value=True):
+        submodules = "test.test.test"
+        assert str(Path(_package_to_dir("test", submodules))) == str(
+            Path("test/test.test.test/")
+        )
+    with mock.patch("noprint.module.os.path.isdir", return_value=False):
+        submodules = "test.test.test"
+        assert _package_to_dir("test", submodules) is None

--- a/tests/test_sprint.py
+++ b/tests/test_sprint.py
@@ -10,7 +10,7 @@ import noprint.logger as logging
 from noprint.sprint import _get_subpackages, _get_prints, _parse_pyfile
 from noprint.exceptions import ImportException
 
-
+'''
 @pytest.mark.parametrize("origin", [None, "origin", "__init__.py"])
 @pytest.mark.parametrize("name", [None, "name", "__pycache__"])
 @mock.patch("noprint.sprint.os")
@@ -93,6 +93,7 @@ def test__get_subpackages__import_exc(mock_spec):
         next(_get_subpackages("noprint")).args[0]
         == "Module [noprint] raised StopIteration on import"
     )
+'''
 
 
 @pytest.mark.parametrize("code", ["print('')", "", "i=1"])

--- a/tests/test_sprint.py
+++ b/tests/test_sprint.py
@@ -1,5 +1,5 @@
 """
-Module with tests for noprint.print_seeker
+Module with tests for noprint.sprint
 """
 from unittest import mock
 
@@ -8,92 +8,88 @@ import pytest
 import noprint.logger as logging
 
 from noprint.sprint import _get_subpackages, _get_prints, _parse_pyfile
-from noprint.exceptions import ImportException
+from noprint.exceptions import ImportException, ParentModuleNotFoundException
 
-'''
+
 @pytest.mark.parametrize("origin", [None, "origin", "__init__.py"])
 @pytest.mark.parametrize("name", [None, "name", "__pycache__"])
 @mock.patch("noprint.sprint.os")
-@mock.patch("noprint.sprint.find_spec")
-def test__get_subpackages__correct(mock_spec, mock_os, origin, name):
+def test__get_subpackages__correct(mock_os, origin, name):
     """Testing function for _get_subpackages - mock several different module specs and finish with a proper one"""
     if origin is None and name is None:
         mod_mock = None
     else:
-        mod_mock = mock.Mock()
-        mod_mock.origin = origin
+        mod_mock = mock.MagicMock()
+        mod_mock.origin = [origin] if origin is not None else []
         mod_mock.name = name
         mod_mock.submodule_search_locations = ["loc"]
 
-    mod_mock_e = mock.Mock()
-    mod_mock_e.origin = "origin"
+    mod_mock_e = mock.MagicMock()
+    mod_mock_e.origin = ["origin"]
     mod_mock_e.name = "name"
     mod_mock_e.submodule_search_locations = ["loc"]
 
     mock_os.listdir.return_value = ["name"]
 
-    mock_spec.side_effect = [
-        spec
-        for specs in [[mod_mock] * 2, [mod_mock] * 2, [mod_mock_e] * 2]
-        for spec in specs
-    ]
-    for package in _get_subpackages("noprint", verbose=True):
-        assert package is not None
+    with mock.patch("noprint.sprint.Module") as mock_mod:
+        mock_mod.side_effect = [
+            spec
+            for specs in [[mod_mock] * 2, [mod_mock] * 2, [mod_mock_e] * 2]
+            for spec in specs
+        ]
+        for package in _get_subpackages("noprint", verbose=True):
+            assert package is not None
 
 
-@pytest.mark.parametrize("spec", [None, mock.Mock(), True])
+@pytest.mark.parametrize("spec", [None, mock.MagicMock(), True])
 @mock.patch("noprint.sprint.logging")
-@mock.patch("noprint.sprint.find_spec")
-def test__get_subpackages__missing_uninstalled_overshadowing(
-    mock_spec, mock_logging, spec
-):
+def test__get_subpackages__missing_uninstalled_overshadowing(mock_logging, spec):
     """Testing function for _get_subpackages - mock several different module specs and finish with a proper one"""
-    spec_system = mock.Mock()
+    spec_system = mock.MagicMock()
 
     mock_logging.WARNING = logging.WARNING
     mock_logging.log = mock.MagicMock()
 
-    if isinstance(spec, bool):
-        spec = mock.Mock()
-        mock_spec.side_effect = [spec, spec_system]
+    with mock.patch("noprint.sprint.Module") as mock_mod:
+        if isinstance(spec, bool):
+            spec = mock.MagicMock()
+            mock_mod.side_effect = [spec, spec_system]
 
-        for _ in _get_subpackages("noprint", verbose=True):
-            pass
-        args = mock_logging.log.mock_calls
-        assert len(args) == 1
-        assert args[0] == mock.call(
-            "Module [noprint] is overshadowing installed module", 30
-        )
-        return
-    if spec:
-        mock_spec.side_effect = [spec, None]
+            for _ in _get_subpackages("noprint", verbose=True):
+                pass
+            args = mock_logging.log.mock_calls
+            assert len(args) == 1
+            assert args[0] == mock.call(
+                "Module [noprint] is overshadowing installed module", 30
+            )
+            return
+        if spec:
+            mock_mod.side_effect = [spec, None]
 
-        for _ in _get_subpackages("noprint", verbose=True):
-            pass
-        args = mock_logging.log.mock_calls
-        assert len(args) == 1
-        assert args[0] == mock.call("Module [noprint] is not installed", 30)
-    else:
-        mock_spec.side_effect = [spec, spec_system]
-        assert (
-            next(_get_subpackages("noprint")).args[0]
-            == "Module [noprint] is not present in current environment, directory or PYTHONPATH"
-        )
+            for _ in _get_subpackages("noprint", verbose=True):
+                pass
+            args = mock_logging.log.mock_calls
+            assert len(args) == 1
+            assert args[0] == mock.call("Module [noprint] is not installed", 30)
+        else:
+            mock_mod.side_effect = [spec, spec_system]
+            assert (
+                next(_get_subpackages("noprint")).args[0]
+                == "Module [noprint] is not present in current environment, directory or PYTHONPATH"
+            )
 
 
-@mock.patch("noprint.sprint.find_spec")
-def test__get_subpackages__import_exc(mock_spec):
+def test__get_subpackages__import_exc():
     """Testing function for _get_subpackages - mock several different module specs and finish with a proper one"""
-    mock_spec.side_effect = [Exception("Dummy exception")]
-    assert (
-        next(_get_subpackages("noprint")).args[0]
-        == "Module [noprint] raised Exception on import"
-    )
-    assert (
-        next(_get_subpackages("noprint")).args[0]
-        == "Module [noprint] raised StopIteration on import"
-    )
-'''
+
+    with mock.patch("noprint.sprint.Module") as mock_mod:
+        mock_mod.side_effect = [ParentModuleNotFoundException("Dummy exception")]
+        fun = iter(_get_subpackages("noprint"))
+        res = next(fun).args[0]
+        assert type(res) == ParentModuleNotFoundException
+        assert str(res) == "Dummy exception"
+        with pytest.raises(StopIteration):
+            next(fun)
 
 
 @pytest.mark.parametrize("code", ["print('')", "", "i=1"])
@@ -108,7 +104,7 @@ def test__parse_pyfile(mock_open, mod, first, code):
     mock_open.return_value.__enter__ = fin
 
     module = mock.Mock()
-    module.origin = "noprint"
+    module.origin = ["noprint"]
     module.name = "noprint"
 
     if mod is None:

--- a/tests/test_sprint.py
+++ b/tests/test_sprint.py
@@ -57,17 +57,19 @@ def test_parse_module(origin, sub_pkgs):
         assert len(result[1]) == len(sub_pkgs)
 
 
-def _parse_mock(package, verbose):
+def _parse_mock(package, verbose):  # pylint:disable=unused-argument
+    """Helper function for mocking _parse_module (Pool pickling)"""
     return (package, [])
 
 
 def test_pf_packages_iter():
-    pf = PackageFinder(1)
+    """Testing PackageFinder.packages_iter"""
+    pkg_finder = PackageFinder(1)
 
-    noprint.sprint._parse_module = _parse_mock
+    noprint.sprint._parse_module = _parse_mock  # pylint:disable=protected-access
 
     packages = ("source", "test")
-    assert set([x for x in pf.packages_iter(packages=packages)]) == set(packages)
+    assert set(pkg_finder.packages_iter(packages=packages)) == set(packages)
 
 
 @pytest.mark.parametrize(
@@ -96,7 +98,7 @@ def test__get_module__import_exc(ret):
 
     with mock.patch("noprint.sprint.Module") as mock_mod, pytest.raises(
         ImportException
-    ) as exc:
+    ):
         if ret is None:
             mock_mod.return_value = ret
         else:
@@ -155,7 +157,7 @@ def test__parse_pyfile(mock_open, mod, first, code):
 @mock.patch(
     "noprint.sprint._parse_pyfile", side_effect=lambda module, first_only: module
 )
-def test_pf_run(mock_parse, mod, first):
+def test_pf_run(mock_parse, mod, first):  # pylint: disable=unused-argument
     """Testing function for _get_prints - verifying if code contains print statements"""
 
     def _subpackages(package, _):  # pylint: disable=unused-argument

--- a/tests/test_sprint.py
+++ b/tests/test_sprint.py
@@ -5,25 +5,28 @@ from unittest import mock
 
 import pytest
 
-import noprint.logger as logging
+import noprint
 
-from noprint.sprint import PackageFinder, _parse_pyfile, _get_module
+from noprint.sprint import (
+    PackageFinder,
+    _parse_pyfile,
+    _get_module,
+    _get_subpackages,
+    _parse_module,
+)
 from noprint.exceptions import ImportException, ParentModuleNotFoundException
 
 
 @pytest.mark.parametrize("origin", [None, "origin", "__init__.py"])
-@pytest.mark.parametrize("name", [None, "name", "__pycache__"])
+@pytest.mark.parametrize("name", ["name", "__pycache__"])
 @mock.patch("noprint.sprint.os")
-def _get_subpackages__correct(mock_os, origin, name):
+def test_get_subpackages(mock_os, origin, name):
     """Testing function for _get_subpackages - mock several different module specs and finish with a proper one"""
-    if origin is None and name is None:
-        mod_mock = None
-    else:
-        mod_mock = mock.MagicMock()
-        mod_mock.origin = [origin] if origin is not None else []
-        mod_mock.name = name
-        mod_mock.search_path = "loc"
-        mod_mock.submodule_search_locations = ["loc"]
+    mod_mock = mock.MagicMock()
+    mod_mock.origin = [origin] if origin is not None else []
+    mod_mock.name = name
+    mod_mock.search_path = "loc"
+    mod_mock.submodule_search_locations = ["loc"]
 
     mod_mock_e = mock.MagicMock()
     mod_mock_e.origin = ["origin"]
@@ -33,55 +36,48 @@ def _get_subpackages__correct(mock_os, origin, name):
 
     mock_os.listdir.return_value = ["name"]
 
-    with mock.patch("noprint.sprint.Module") as mock_mod:
-        mock_mod.side_effect = [
-            spec
-            for specs in [[mod_mock] * 2, [mod_mock] * 2, [mod_mock_e] * 2]
-            for spec in specs
-        ]
-        for package in _get_subpackages("noprint", verbose=True):
-            assert package is not None
+    for package in _get_subpackages("noprint", verbose=True, module=mod_mock):
+        assert package is not None
 
 
-@pytest.mark.parametrize("spec", [None, mock.MagicMock(), True])
-@mock.patch("noprint.sprint.logging")
-def _get_subpackages__missing_uninstalled_overshadowing(mock_logging, spec):
+@pytest.mark.parametrize("sub_pkgs", [[], [mock.Mock()], [mock.Mock(), mock.Mock()]])
+@pytest.mark.parametrize("origin", [None, "origin"])
+def test_parse_module(origin, sub_pkgs):
     """Testing function for _get_subpackages - mock several different module specs and finish with a proper one"""
-    spec_system = mock.MagicMock()
-
-    mock_logging.WARNING = logging.WARNING
-    mock_logging.log = mock.MagicMock()
-
-    with mock.patch("noprint.sprint.Module") as mock_mod:
-        if isinstance(spec, bool):
-            spec = mock.MagicMock()
-            mock_mod.side_effect = [spec, spec_system]
-
-            for _ in _get_subpackages("noprint", verbose=True):
-                pass
-            args = mock_logging.log.mock_calls
-            assert len(args) == 1
-            assert args[0] == mock.call(
-                "Module [noprint] is overshadowing installed module", 30
-            )
-            return
-        if spec:
-            mock_mod.side_effect = [spec, None]
-
-            for _ in _get_subpackages("noprint", verbose=True):
-                pass
-            args = mock_logging.log.mock_calls
-            assert len(args) == 1
-            assert args[0] == mock.call("Module [noprint] is not installed", 30)
+    module = mock.Mock()
+    module.origin = origin
+    with mock.patch("noprint.sprint._get_module", return_value=module), mock.patch(
+        "noprint.sprint._get_subpackages", return_value=sub_pkgs
+    ):
+        result = _parse_module(package="noprint")
+        if module.origin:
+            assert result[0] == module
         else:
-            mock_mod.side_effect = [spec, spec_system]
-            assert (
-                next(_get_subpackages("noprint")).args[0]
-                == "Module [noprint] is not present in current environment, directory or PYTHONPATH"
-            )
+            assert result[0] is None
+        assert len(result[1]) == len(sub_pkgs)
 
 
-@pytest.mark.parametrize("ret", [[mock.MagicMock(), mock.MagicMock()], [mock.MagicMock(), None], [mock.MagicMock()]*2])
+def _parse_mock(package, verbose):
+    return (package, [])
+
+
+def test_pf_packages_iter():
+    pf = PackageFinder(1)
+
+    noprint.sprint._parse_module = _parse_mock
+
+    packages = ("source", "test")
+    assert set([x for x in pf.packages_iter(packages=packages)]) == set(packages)
+
+
+@pytest.mark.parametrize(
+    "ret",
+    [
+        [mock.MagicMock(), mock.MagicMock()],
+        [mock.MagicMock(), None],
+        [mock.MagicMock()] * 2,
+    ],
+)
 def test__get_module__mod(ret):
     """Testing function for _get_subpackages - mock several different module specs and finish with a proper one"""
 
@@ -92,12 +88,15 @@ def test__get_module__mod(ret):
         _get_module("noprint", verbose=True)
 
 
-@pytest.mark.parametrize("ret", [None, ParentModuleNotFoundException("Dummy exception")])
+@pytest.mark.parametrize(
+    "ret", [None, ParentModuleNotFoundException("Dummy exception")]
+)
 def test__get_module__import_exc(ret):
     """Testing function for _get_subpackages - mock several different module specs and finish with a proper one"""
 
-    with mock.patch("noprint.sprint.Module") as mock_mod, \
-            pytest.raises(ImportException) as exc:
+    with mock.patch("noprint.sprint.Module") as mock_mod, pytest.raises(
+        ImportException
+    ) as exc:
         if ret is None:
             mock_mod.return_value = ret
         else:
@@ -153,9 +152,10 @@ def test__parse_pyfile(mock_open, mod, first, code):
         ),
     ],
 )
-@mock.patch("noprint.sprint._parse_pyfile", side_effect=lambda module, first_only: module)
-@mock.patch("noprint.sprint.Pool")
-def test_pf_run(mock_pool, mock_parse, mod, first):
+@mock.patch(
+    "noprint.sprint._parse_pyfile", side_effect=lambda module, first_only: module
+)
+def test_pf_run(mock_parse, mod, first):
     """Testing function for _get_prints - verifying if code contains print statements"""
 
     def _subpackages(package, _):  # pylint: disable=unused-argument
@@ -165,7 +165,9 @@ def test_pf_run(mock_pool, mock_parse, mod, first):
         if i == 10:
             return
 
-    with mock.patch("noprint.sprint.PackageFinder.packages_iter", side_effect=_subpackages):
+    with mock.patch(
+        "noprint.sprint.PackageFinder.packages_iter", side_effect=_subpackages
+    ):
         prints = PackageFinder(1).run(
             packages=["noprint"], first_only=first, verbose=True
         )

--- a/tests/test_sprint.py
+++ b/tests/test_sprint.py
@@ -22,11 +22,13 @@ def test__get_subpackages__correct(mock_os, origin, name):
         mod_mock = mock.MagicMock()
         mod_mock.origin = [origin] if origin is not None else []
         mod_mock.name = name
+        mod_mock.search_path = "loc"
         mod_mock.submodule_search_locations = ["loc"]
 
     mod_mock_e = mock.MagicMock()
     mod_mock_e.origin = ["origin"]
     mod_mock_e.name = "name"
+    mod_mock_e.search_path = "loc"
     mod_mock_e.submodule_search_locations = ["loc"]
 
     mock_os.listdir.return_value = ["name"]


### PR DESCRIPTION
This overhaul makes it possible to find submodule files without importing parent packages. There might be some caveats when using non-standard module naming (e.g. dots in directory names).

Moved parallelism logic from file parsing to file/module search. Added caching for finding parent package path.

Time improvement: Tensorflow package now takes about a minute to parse with 24 threads instead of more than 10min that was before.